### PR TITLE
chore(npmrc): lock npm package versions when running `npm install <package>`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
Close: #9 